### PR TITLE
fix adding base url to uri that already has it

### DIFF
--- a/lib/reso_api/app/models/reso/api/client.rb
+++ b/lib/reso_api/app/models/reso/api/client.rb
@@ -132,7 +132,11 @@ module RESO
       end
 
       def uri_for_endpoint endpoint
-        return URI([base_url, endpoint].join)
+        if endpoint.start_with?(base_url)
+          URI(endpoint)
+        else
+          URI([base_url, endpoint].join)
+        end
       end
 
       def perform_call(endpoint, params)

--- a/lib/reso_api/version.rb
+++ b/lib/reso_api/version.rb
@@ -1,3 +1,3 @@
 module ResoApi
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
<img width="721" alt="image" src="https://user-images.githubusercontent.com/11808/160019995-b13a0787-0f1f-4081-9c65-93c00717c693.png">
The value from Trestle @odata.nextLink already had the base_url in it so passing it to `uri_for_endpoint` made the wrong url.