### PR TITLE
Add option to batch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ client.properties(expand: "Media")
 
 #### Automatically iterate over all results
 
-By passing a block to Media, Member, Office, and Property resource calls, subsequent paginated calls will automatically be made until the whole result set has been traversed. The block provided is executed for each returned object hash.
+By passing a block to Media, Member, Office, and Property resource calls, subsequent paginated calls will automatically be made until the whole result set has been traversed. The block provided is executed for each returned object hash. The `batch` option can be used to return the full array of results. 
 
 Here are a couple of examples of how that can be used:
 
@@ -156,6 +156,10 @@ end
 
 client.properties(filter: "StandardStatus eq 'Active'") do |hash|
   Listing.create(listing_key: hash['ListingKey'], data: hash)
+end
+
+client.properties(filter: "StandardStatus eq 'Active'", batch: true) do |results|
+  Listing.insert_all(results) # Perform some batch operation
 end
 ```
 

--- a/lib/reso_api/app/models/reso/api/client.rb
+++ b/lib/reso_api/app/models/reso/api/client.rb
@@ -64,10 +64,17 @@ module RESO
           }.compact
           if !block.nil?
             response = perform_call(endpoint, params)
-            response["value"].each{|hash| block.call(hash)} if response["value"].class.eql?(Array)
+            
+            if response["value"].class.eql?(Array)
+              hash[:batch] ? block.call(response["value"]) : response["value"].each{|hash| block.call(hash)} 
+            end
+
             while (next_link = response["@odata.nextLink"]).present?
               response = perform_call(next_link, nil)
-              response["value"].each{|hash| block.call(hash)} if response["value"].class.eql?(Array)
+              
+              if response["value"].class.eql?(Array)
+                hash[:batch] ? block.call(response["value"]) : response["value"].each{|hash| block.call(hash)} 
+              end
             end
           else
             return perform_call(endpoint, params)


### PR DESCRIPTION
This is useful for batch create/update/upsert during full syncs

```ruby
client.properties(top: 500, batch: true) do |properties|
   Property.insert_all(properties) # Perform some batch operation
end
```