### PR TITLE
Add support for Bridge Interactive replication endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ You pass these two pieces of information to create an instance of an API client:
 client = RESO::API::Client.new(access_token: access_token, base_url: base_url)
 ```
 
+#### Base URL for Replication
+
+Some systems, like Bridge Interactive, provide replication endpoints that differ from the ones for normal search requests by including an additional path segment *following* the resource segment. For example:
+
+    https://api.bridgedataoutput.com/api/v2/OData/{dataset_id}/Property/replication
+
+To accommodate this, the `base_url` parameter may contain a `/$resource$` segment which will be replaced for each API call with the appropriate resource segment.
+
 
 ### Resources
 
@@ -96,7 +104,7 @@ The response will be an EDMX xml schema document that matches the [RESO Data Dic
 
 ### Listing Requests
 
-The simplest query is simply to call `properties` on the initialized client: 
+The simplest query is simply to call `properties` on the initialized client:
 
 ```ruby
 client.properties
@@ -106,7 +114,7 @@ The API will return a JSON response with an array of listing JSON objects.
 
 ### Getting a single listing
 
-You can look up a single listing by sending a query with the listing's unique id (ListingKey). 
+You can look up a single listing by sending a query with the listing's unique id (ListingKey).
 
 ```ruby
 client.property('3yd-BINDER-5508272')
@@ -195,7 +203,7 @@ client.properties(ignorenulls: true)
 
 #### Automatically iterate over all results
 
-By passing a block to Media, Member, Office, and Property resource calls, subsequent paginated calls will automatically be made until the whole result set has been traversed. The block provided is executed for each returned object hash. The `batch` option can be used to return the full array of results. 
+By passing a block to Media, Member, Office, and Property resource calls, subsequent paginated calls will automatically be made until the whole result set has been traversed. The block provided is executed for each returned object hash. The `batch` option can be used to return the full array of results.
 
 Here are a couple of examples of how that can be used:
 

--- a/lib/reso_api/app/models/reso/api/client.rb
+++ b/lib/reso_api/app/models/reso/api/client.rb
@@ -59,8 +59,8 @@ module RESO
         define_method method_name do |*args, &block|
           hash = args.first.is_a?(Hash) ? args.first : {}
 
-          filter = hash[:filter].to_s
-          if !filter.include?('OriginatingSystemName') && osn.present?
+          filter = hash[:filter]
+          if !filter.to_s.include?('OriginatingSystemName') && osn.present?
             osn_filter = format("OriginatingSystemName eq '%s'", osn.to_s)
             filter = [filter.presence, osn_filter].compact.join(' and ')
           end
@@ -275,7 +275,7 @@ module RESO
             fresh_oauth2_payload
             raise StandardError
           elsif response.is_a?(Hash) && response.has_key?("error")
-            error_msg = response.inspect
+            error_msg = "#{@last_request_url} => #{response.inspect}"
             puts "Error: #{error_msg}" if debug
             raise StandardError, error_msg
           elsif response.is_a?(Hash) && response.has_key?("retry-after")

--- a/lib/reso_api/app/models/reso/api/client.rb
+++ b/lib/reso_api/app/models/reso/api/client.rb
@@ -227,7 +227,12 @@ module RESO
       end
 
       def uri_for_endpoint endpoint
-        return URI(endpoint).host ? URI(endpoint) : URI([base_url, endpoint].join)
+        uri = URI(endpoint)
+        return uri if uri.host
+        uri = URI(base_url)
+        path = uri.path
+        uri.path = path.include?("/$resource$") ? path.sub("/$resource$", endpoint) : [path, endpoint].join
+        return uri
       end
 
       def perform_call(endpoint, params, max_retries = 5, debug = false)


### PR DESCRIPTION
Bridge Interactive replication endpoints differ from the ones for normal search requests by including an additional path segment *following* the resource segment. To accommodate this, allow the `base_url` parameter to contain a `/$resource$` segment which will be replaced for each API call with the appropriate resource segment.

Also fixes  an issue by which passing a `filter:` value of `nil` produces an invalid `$filter` parameter in the request URL. 